### PR TITLE
strip newlines off the end of env variable values

### DIFF
--- a/rock/config.py
+++ b/rock/config.py
@@ -87,7 +87,8 @@ class Config(collections.Mapping):
                         raise ConfigError('%s.%s must be a string' %
                                           (env, name))
                 dst['env'][name] = string.Template(
-                    src[env][name]).safe_substitute(**dst['env'])
+                    src[env][name]).safe_substitute(**dst['env']).rstrip("\n")
+
             del src[env]
 
     def merge(self, src, dst):


### PR DESCRIPTION
When putting multiline expressions in the `env` section in the
.rock.yml, the values wind up with an extra newline on the end. This
strips that off.

For example:

.rock.yml:

```
env:
  INTEGRATION_DB_HOST: |
    `case $JOB_NAME in
      *-qa)   echo -n "jenkins-test-db.qa.example.net"    ;;
      *-prod) echo -n "jenkins-test-db.prod.example.net"  ;;
      *)      echo -n "jenkins-test-db.dev.example.net"   ;;
    esac`
```

$ rock env

```
# ---- SNIP ---
export INTEGRATION_DB_HOST="`case $JOB_NAME in
  *-qa)   echo -n "jenkins-test-db.qa.example.net"    ;;
  *-prod) echo -n "jenkins-test-db.prod.example.net"  ;;
  *)      echo -n "jenkins-test-db.dev.example.net"   ;;
esac`
"
```

Note the newline after the `esac`'s closing backtick.
