### PR TITLE
improve 'runtime path doesn't exist' error

### DIFF
--- a/rock/config.py
+++ b/rock/config.py
@@ -199,7 +199,9 @@ class Config(collections.Mapping):
             data_path = self.data_path('runtime', file_name)
         # ensure runtime exists
         if not os.path.isdir(runtime.path()):
-            raise ConfigError("runtime path doesn't exist")
+            raise ConfigError(
+                "%s runtime path doesn't exist" % data['runtime']
+            )
         # parse configs
         runtime_config = self.parse(runtime.path('rock.yml'))
         rock_config = self.parse(data_path, require_exists=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,7 +111,7 @@ class ConfigTestCase(helper.unittest.TestCase):
 
     def test_runtime_notfound(self):
         c = self.setup('runtime_notfound')
-        with self.assertRaisesRegexp(ConfigError, r"runtime path doesn't exist") as a:
+        with self.assertRaisesRegexp(ConfigError, r"none runtime path doesn't exist") as a:
             c['path']
 
     def test_runtime_config_notfound(self):


### PR DESCRIPTION
I had a hard time troubleshooting this error at first. Adding the runtime name (perl516 in my case) would have made the problem immediately clear.

$ rock run
perl516 runtime path doesn't exist
